### PR TITLE
Fix typo in `VideoScalingType`: `SCAPE_ASPECT_FILL` -> `SCALE_ASPECT_FILL`

### DIFF
--- a/stream-webrtc-android-compose/api/stream-webrtc-android-compose.api
+++ b/stream-webrtc-android-compose/api/stream-webrtc-android-compose.api
@@ -14,10 +14,15 @@ public final class io/getstream/webrtc/android/compose/VideoRendererKt {
 }
 
 public final class io/getstream/webrtc/android/compose/VideoScalingType : java/lang/Enum {
+	public static final field Companion Lio/getstream/webrtc/android/compose/VideoScalingType$Companion;
 	public static final field SCALE_ASPECT_BALANCED Lio/getstream/webrtc/android/compose/VideoScalingType;
+	public static final field SCALE_ASPECT_FILL Lio/getstream/webrtc/android/compose/VideoScalingType;
 	public static final field SCALE_ASPECT_FIT Lio/getstream/webrtc/android/compose/VideoScalingType;
 	public static final field SCAPE_ASPECT_FILL Lio/getstream/webrtc/android/compose/VideoScalingType;
 	public static fun valueOf (Ljava/lang/String;)Lio/getstream/webrtc/android/compose/VideoScalingType;
 	public static fun values ()[Lio/getstream/webrtc/android/compose/VideoScalingType;
+}
+
+public final class io/getstream/webrtc/android/compose/VideoScalingType$Companion {
 }
 

--- a/stream-webrtc-android-compose/src/main/kotlin/io/getstream/webrtc/android/compose/VideoScalingType.kt
+++ b/stream-webrtc-android-compose/src/main/kotlin/io/getstream/webrtc/android/compose/VideoScalingType.kt
@@ -32,14 +32,22 @@ import org.webrtc.RendererCommon
  */
 public enum class VideoScalingType {
   SCALE_ASPECT_FIT,
-  SCAPE_ASPECT_FILL,
+  SCALE_ASPECT_FILL,
   SCALE_ASPECT_BALANCED;
 
-  internal companion object {
+  public companion object {
+
+    @Deprecated(
+      message = "Use SCALE_ASPECT_FILL instead",
+      replaceWith = ReplaceWith("VideoScalingType.SCALE_ASPECT_FILL")
+    )
+    @JvmField
+    public val SCAPE_ASPECT_FILL: VideoScalingType = SCALE_ASPECT_FILL
+
     internal fun VideoScalingType.toCommonScalingType(): RendererCommon.ScalingType {
       return when (this) {
         SCALE_ASPECT_FIT -> RendererCommon.ScalingType.SCALE_ASPECT_FIT
-        SCAPE_ASPECT_FILL -> RendererCommon.ScalingType.SCALE_ASPECT_FILL
+        SCALE_ASPECT_FILL -> RendererCommon.ScalingType.SCALE_ASPECT_FILL
         SCALE_ASPECT_BALANCED -> RendererCommon.ScalingType.SCALE_ASPECT_BALANCED
       }
     }


### PR DESCRIPTION
### 🎯 Goal

There is a small typo in enum entry `VideoScalingType.SCAPE_ASPECT_FILL` — should be `SCALE_ASPECT_FILL`.

### 🛠 Implementation details

To maintain binary compatibility for the old value, I opted to move it to `companion object` as `@JvmField`. Unfortunately, this forces the companion to be `public`. I figured it's better than keeping it as an enum entry which, e.g., would break existing `when` statements.

Let me know if there's a better way.