### PR TITLE
Fix aspect ratio in VideoTextureViewRenderer when frame dimensions change

### DIFF
--- a/stream-webrtc-android-ui/src/main/kotlin/io/getstream/webrtc/android/ui/VideoTextureViewRenderer.kt
+++ b/stream-webrtc-android-ui/src/main/kotlin/io/getstream/webrtc/android/ui/VideoTextureViewRenderer.kt
@@ -158,6 +158,8 @@ public open class VideoTextureViewRenderer @JvmOverloads constructor(
       rotatedFrameHeight = videoFrame.rotatedHeight
       frameRotation = videoFrame.rotation
 
+      requestLayout()
+
       uiThreadHandler.post {
         rendererEvents?.onFrameResolutionChanged(
           rotatedFrameWidth,


### PR DESCRIPTION
We need to call `requestLayout()` when the frame dimensions change in `VideoTextureViewRender`. If we don't do this then `setLayoutAspectRatio(..)` in `onLayout()` is not called and the `EglRenderer` will then not properly draw the content because the frame size and aspect ratio are out of sync (aspect ratio is not updated). 

We found this error thanks to the issue report in https://github.com/GetStream/stream-video-android/issues/679 - changing the scaling type with `VideoTextureViewRenderer.setScalingType(..)` would not have an effect.

I tested this change with our Video SDK demo app. 