### PR TITLE
Use software decoder fallback for codec exceptions

### DIFF
--- a/stream-webrtc-android/src/main/java/org/webrtc/AndroidVideoDecoder.java
+++ b/stream-webrtc-android/src/main/java/org/webrtc/AndroidVideoDecoder.java
@@ -283,7 +283,12 @@ class AndroidVideoDecoder implements VideoDecoder, VideoSink {
     } catch (IllegalStateException e) {
       Logging.e(TAG, "queueInputBuffer failed", e);
       frameInfos.pollLast();
-      return VideoCodecStatus.ERROR;
+      if (e instanceof MediaCodec.CodecException) {
+        // For codec exceptions we can try to use the software fallback
+        return VideoCodecStatus.FALLBACK_SOFTWARE;
+      } else {
+        return VideoCodecStatus.ERROR;
+      }
     }
     if (keyFrameRequired) {
       keyFrameRequired = false;


### PR DESCRIPTION
We discovered a bug when screensharing from Firefox into Android would throw a `MediaCodec.CodecException` (Error code 0x1) when a larger resolution window was shared. Falling back to the software decoder fixes the problem in this specific case and should generally be a good "last try" approach. 