### PR TITLE
Fix onFirstFrameRendered() not called in VideoTextureViewRenderer

### DIFF
--- a/stream-webrtc-android-ui/src/main/kotlin/io/getstream/webrtc/android/ui/VideoTextureViewRenderer.kt
+++ b/stream-webrtc-android-ui/src/main/kotlin/io/getstream/webrtc/android/ui/VideoTextureViewRenderer.kt
@@ -145,7 +145,7 @@ public open class VideoTextureViewRenderer @JvmOverloads constructor(
    * Updates the frame data and notifies [rendererEvents] about the changes.
    */
   private fun updateFrameData(videoFrame: VideoFrame) {
-    if (isFirstFrameRendered) {
+    if (!isFirstFrameRendered) {
       rendererEvents?.onFirstFrameRendered()
       isFirstFrameRendered = true
     }


### PR DESCRIPTION
The `RendererEvents.onFirstFrameRendered()` is never called because `isFirstFrameRendered` is set to `false` by default and the condition is wrong.