### PR TITLE
Add a way to intercept the audio samples before processing

### DIFF
--- a/stream-webrtc-android/api/stream-webrtc-android.api
+++ b/stream-webrtc-android/api/stream-webrtc-android.api
@@ -1974,6 +1974,10 @@ public abstract interface class org/webrtc/audio/AudioDeviceModule {
 	public abstract fun setSpeakerMute (Z)V
 }
 
+public abstract interface class org/webrtc/audio/AudioRecordDataCallback {
+	public abstract fun onAudioDataRecorded (IIILjava/nio/ByteBuffer;)V
+}
+
 public class org/webrtc/audio/JavaAudioDeviceModule : org/webrtc/audio/AudioDeviceModule {
 	public static fun builder (Landroid/content/Context;)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
 	public fun getNativeAudioDeviceModulePointer ()J
@@ -2033,6 +2037,7 @@ public class org/webrtc/audio/JavaAudioDeviceModule$Builder {
 	public fun createAudioDeviceModule ()Lorg/webrtc/audio/JavaAudioDeviceModule;
 	public fun setAudioAttributes (Landroid/media/AudioAttributes;)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
 	public fun setAudioFormat (I)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
+	public fun setAudioRecordDataCallback (Lorg/webrtc/audio/AudioRecordDataCallback;)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
 	public fun setAudioRecordErrorCallback (Lorg/webrtc/audio/JavaAudioDeviceModule$AudioRecordErrorCallback;)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
 	public fun setAudioRecordStateCallback (Lorg/webrtc/audio/JavaAudioDeviceModule$AudioRecordStateCallback;)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;
 	public fun setAudioSource (I)Lorg/webrtc/audio/JavaAudioDeviceModule$Builder;

--- a/stream-webrtc-android/src/main/java/org/webrtc/audio/AudioRecordDataCallback.java
+++ b/stream-webrtc-android/src/main/java/org/webrtc/audio/AudioRecordDataCallback.java
@@ -1,0 +1,16 @@
+package org.webrtc.audio;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
+
+public interface AudioRecordDataCallback {
+  /**
+   * Invoked after an audio sample is recorded. Can be used to manipulate
+   * the ByteBuffer before it's fed into WebRTC. Currently the audio in the
+   * ByteBuffer is always PCM 16bit and the buffer sample size is ~10ms.
+   *
+   * @param audioFormat format in android.media.AudioFormat
+   */
+  void onAudioDataRecorded(int audioFormat, int channelCount, int sampleRate, @NonNull ByteBuffer audioBuffer);
+}

--- a/stream-webrtc-android/src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java
+++ b/stream-webrtc-android/src/main/java/org/webrtc/audio/JavaAudioDeviceModule.java
@@ -54,6 +54,7 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     private AudioAttributes audioAttributes;
     private boolean useLowLatency;
     private boolean enableVolumeLogger;
+    private AudioRecordDataCallback audioRecordDataCallback;
 
     private Builder(Context context) {
       this.context = context;
@@ -227,6 +228,16 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
     }
 
     /**
+     * Can be used to gain access to the raw ByteBuffer from the recording device before it's
+     * fed into WebRTC. You can use this to manipulate the ByteBuffer (e.g. audio filters).
+     * Make sure that the operation is fast.
+     */
+    public Builder setAudioRecordDataCallback(AudioRecordDataCallback audioRecordDataCallback) {
+      this.audioRecordDataCallback = audioRecordDataCallback;
+      return this;
+    }
+
+    /**
      * Construct an AudioDeviceModule based on the supplied arguments. The caller takes ownership
      * and is responsible for calling release().
      */
@@ -260,7 +271,7 @@ public class JavaAudioDeviceModule implements AudioDeviceModule {
       }
       final WebRtcAudioRecord audioInput = new WebRtcAudioRecord(context, executor, audioManager,
         audioSource, audioFormat, audioRecordErrorCallback, audioRecordStateCallback,
-        samplesReadyCallback, useHardwareAcousticEchoCanceler, useHardwareNoiseSuppressor);
+        samplesReadyCallback, audioRecordDataCallback, useHardwareAcousticEchoCanceler, useHardwareNoiseSuppressor);
       final WebRtcAudioTrack audioOutput =
         new WebRtcAudioTrack(context, audioManager, audioAttributes, audioTrackErrorCallback,
           audioTrackStateCallback, useLowLatency, enableVolumeLogger);


### PR DESCRIPTION
The PR adds a new `setAudioRecordDataCallback(...)` function into the `JavaAudioDeviceModule.Builder`.  This can be used to intercept the raw `ByteBuffer` with the capture audio sample before it's sent to the native WebRTC part. The client application can then use it to apply simple audio filters to the audio recorded by the device. 

There is no impact or breaking change on existing clients - the code will not do anything unless a callback is set.  