### PR TITLE
Add H264 hardware decoding for Marvell chips

### DIFF
--- a/stream-webrtc-android/build.gradle.kts
+++ b/stream-webrtc-android/build.gradle.kts
@@ -23,7 +23,7 @@ android {
   compileSdk = 34 //Configurations.compileSdk
 
   defaultConfig {
-    minSdk = 26 //Configurations.minSdk
+    minSdk = 21 //Configurations.minSdk
     consumerProguardFiles("consumer-rules.pro")
   }
 

--- a/stream-webrtc-android/build.gradle.kts
+++ b/stream-webrtc-android/build.gradle.kts
@@ -1,6 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
-import io.getstream.Configurations
+//import io.getstream.Configurations
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
@@ -8,6 +8,7 @@ plugins {
   id(libs.plugins.kotlin.android.get().pluginId)
 }
 
+/*
 rootProject.extra.apply {
   set("PUBLISH_GROUP_ID", Configurations.artifactGroup)
   set("PUBLISH_ARTIFACT_ID", "stream-webrtc-android")
@@ -15,13 +16,14 @@ rootProject.extra.apply {
 }
 
 apply(from ="${rootDir}/scripts/publish-module.gradle")
+*/
 
 android {
   namespace = "org.webrtc"
-  compileSdk = Configurations.compileSdk
+  compileSdk = 34 //Configurations.compileSdk
 
   defaultConfig {
-    minSdk = Configurations.minSdk
+    minSdk = 26 //Configurations.minSdk
     consumerProguardFiles("consumer-rules.pro")
   }
 
@@ -38,6 +40,9 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+  }
+  kotlinOptions {
+    jvmTarget = "11"
   }
 }
 

--- a/stream-webrtc-android/src/main/java/org/webrtc/MediaCodecUtils.java
+++ b/stream-webrtc-android/src/main/java/org/webrtc/MediaCodecUtils.java
@@ -29,6 +29,7 @@ class MediaCodecUtils {
   static final String INTEL_PREFIX = "OMX.Intel.";
   static final String NVIDIA_PREFIX = "OMX.Nvidia.";
   static final String QCOM_PREFIX = "OMX.qcom.";
+  static final String MARVELL_PREFIX = "OMX.Marvell.";
   static final String[] SOFTWARE_IMPLEMENTATION_PREFIXES = {
       "OMX.google.", "OMX.SEC.", "c2.android"};
 
@@ -40,7 +41,9 @@ class MediaCodecUtils {
   static final int COLOR_QCOM_FORMATYUV420PackedSemiPlanar32m = 0x7FA30C04;
 
   // Color formats supported by hardware decoder - in order of preference.
-  static final int[] DECODER_COLOR_FORMATS = new int[] {CodecCapabilities.COLOR_FormatYUV420Planar,
+  static final int[] DECODER_COLOR_FORMATS = new int[] {
+      MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible,
+      CodecCapabilities.COLOR_FormatYUV420Planar,
       CodecCapabilities.COLOR_FormatYUV420SemiPlanar,
       CodecCapabilities.COLOR_QCOM_FormatYUV420SemiPlanar,
       MediaCodecUtils.COLOR_QCOM_FORMATYVU420PackedSemiPlanar32m4ka,

--- a/stream-webrtc-android/src/main/java/org/webrtc/MediaCodecVideoDecoderFactory.java
+++ b/stream-webrtc-android/src/main/java/org/webrtc/MediaCodecVideoDecoderFactory.java
@@ -12,6 +12,7 @@ package org.webrtc;
 
 import static org.webrtc.MediaCodecUtils.EXYNOS_PREFIX;
 import static org.webrtc.MediaCodecUtils.QCOM_PREFIX;
+import static org.webrtc.MediaCodecUtils.MARVELL_PREFIX;
 
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecInfo.CodecCapabilities;
@@ -127,8 +128,8 @@ class MediaCodecVideoDecoderFactory implements VideoDecoderFactory {
 
   private boolean isH264HighProfileSupported(MediaCodecInfo info) {
     String name = info.getName();
-    // Support H.264 HP decoding on QCOM chips.
-    if (name.startsWith(QCOM_PREFIX)) {
+    // Support H.264 HP decoding on QCOM and Marvell chips
+    if (name.startsWith(QCOM_PREFIX) || name.startsWith(MARVELL_PREFIX)) {
       return true;
     }
     // Support H.264 HP decoding on Exynos chips for Android M and above.


### PR DESCRIPTION
### 🎯 Goal
Add support for H264 hardware decoding on Bouygues Telecom's AndroidTV boxes relying on Marvell chips.

### 🛠 Implementation details
Describe the implementation details for this Pull Request.
- Add `MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible` to `MediaCodecUtils.DECODER_COLOR_FORMATS`
- Claim `MediaCodecVideoDecoderFactory.isH264HighProfileSupported()` returns `true` for Marvell chips

### ✍️ Explain examples
Sorry, example code is proprietary.

### Preparing a pull request for review
spotlessApply is OK